### PR TITLE
fix path to llvm-ar

### DIFF
--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -32,9 +32,6 @@ call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefi
     --channel conda-forge ^
     pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 if !errorlevel! neq 0 exit /b !errorlevel!
-echo Moving pkgs cache from %MAMBA_ROOT_PREFIX% to %MINIFORGE_HOME%
-move /Y "%MAMBA_ROOT_PREFIX%\pkgs" "%MINIFORGE_HOME%"
-if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%"
 del /S /Q "%MICROMAMBA_TMPDIR%"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -7,7 +7,7 @@ set "CONDA_BACKUP_AR=%AR%"
 :: flang 19 still uses "temporary" name
 set "FC=flang-new"
 set "LD=lld-link.exe"
-set "AR=lld-ar.exe"
+set "AR=llvm-ar.exe"
 
 :: following https://github.com/conda-forge/clang-win-activation-feedstock/blob/main/recipe/activate-clang_win-64.bat
 set "FFLAGS=-D_CRT_SECURE_NO_WARNINGS -fms-runtime-lib=dll -fuse-ld=lld -I%LIBRARY_INC%"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   # intentionally only windows (main target) & linux (debuggability)
   skip: true  # [osx]
 
@@ -16,6 +16,8 @@ outputs:
     requirements:
       - flang ={{ version }}
       - lld                     # [win]
+      # for llvm-ar.exe
+      - llvm-tools              # [win]
       - compiler-rt_{{ cross_target_platform }} ={{ version }}
     test:
       commands:


### PR DESCRIPTION
Follow-up to #6, which had a mistake in the name (`lld-ar` does not exist; `llvm-ar` [does](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fwin-64%2Fllvm-tools-19.1.3-h2a44499_0.conda)). Also add the required dependency to have it available.