### PR TITLE
use activation style that works outside of conda-build usage

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -10,5 +10,5 @@ set "LD=lld-link.exe"
 set "AR=llvm-ar.exe"
 
 :: following https://github.com/conda-forge/clang-win-activation-feedstock/blob/main/recipe/activate-clang_win-64.bat
-set "FFLAGS=-D_CRT_SECURE_NO_WARNINGS -fms-runtime-lib=dll -fuse-ld=lld -I%LIBRARY_INC%"
+set "FFLAGS=-D_CRT_SECURE_NO_WARNINGS -fms-runtime-lib=dll -fuse-ld=lld -I%CONDA_PREFIX%\Library\include"
 set "LDFLAGS=%LDFLAGS% -Wl,-defaultlib:%CONDA_PREFIX:\=/%/lib/clang/@MAJOR_VER@/lib/windows/clang_rt.builtins-x86_64.lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
   # intentionally only windows (main target) & linux (debuggability)
   skip: true  # [osx]
 


### PR DESCRIPTION
`%LIBRARY_INC%  does not get populated unless we're using conda-build. Use more generic activation so usage as in https://github.com/scipy/scipy/issues/21716 works.