### PR TITLE
[dev] flang-activation v21.0.0.dev0; use flang-rt

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,9 +5,9 @@ CHOST:
 cdt_name:
 - conda
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cross_target_platform:
 - linux-64
 docker_image:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,7 @@
 channel_sources:
-- conda-forge
+- conda-forge/label/llvm_dev,conda-forge
 channel_targets:
-- conda-forge main
+- conda-forge llvm_dev
 cross_target_platform:
 - win-64
 target_platform:

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ Current release info
 Installing flang-activation
 ===========================
 
-Installing `flang-activation` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `flang-activation` from the `conda-forge/label/llvm_dev` channel can be achieved by adding `conda-forge/label/llvm_dev` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/llvm_dev
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `flang_impl_linux-64, flang_impl_win-64, flang_linux-64, flang_win-64` can be installed with `conda`:
+Once the `conda-forge/label/llvm_dev` channel has been enabled, `flang_impl_linux-64, flang_impl_win-64, flang_linux-64, flang_win-64` can be installed with `conda`:
 
 ```
 conda install flang_impl_linux-64 flang_impl_win-64 flang_linux-64 flang_win-64
@@ -85,26 +85,26 @@ mamba install flang_impl_linux-64 flang_impl_win-64 flang_linux-64 flang_win-64
 It is possible to list all of the versions of `flang_impl_linux-64` available on your platform with `conda`:
 
 ```
-conda search flang_impl_linux-64 --channel conda-forge
+conda search flang_impl_linux-64 --channel conda-forge/label/llvm_dev
 ```
 
 or with `mamba`:
 
 ```
-mamba search flang_impl_linux-64 --channel conda-forge
+mamba search flang_impl_linux-64 --channel conda-forge/label/llvm_dev
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search flang_impl_linux-64 --channel conda-forge
+mamba repoquery search flang_impl_linux-64 --channel conda-forge/label/llvm_dev
 
 # List packages depending on `flang_impl_linux-64`:
-mamba repoquery whoneeds flang_impl_linux-64 --channel conda-forge
+mamba repoquery whoneeds flang_impl_linux-64 --channel conda-forge/label/llvm_dev
 
 # List dependencies of `flang_impl_linux-64`:
-mamba repoquery depends flang_impl_linux-64 --channel conda-forge
+mamba repoquery depends flang_impl_linux-64 --channel conda-forge/label/llvm_dev
 ```
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,9 @@
+channel_targets:
+  - conda-forge llvm_dev
+
+channel_sources:
+  - conda-forge/label/llvm_dev,conda-forge
+
 CBUILD:
   - x86_64-conda-linux-gnu      # [linux]
   - x86_64-pc-windows-msvc      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.1.2" %}
+{% set version = "21.0.0.dev1" %}
 
 package:
   name: flang-activation
@@ -7,8 +7,8 @@ package:
 # source:
   # unused, but helpful so the bot creates updates automatically;
   # we use the _signature_, which is tiny and thus much faster to download
-  url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "-rc") }}.src.tar.xz.sig
-  sha256: 2072bd79df3e0d8289d8de56593f3dac9e722906e931dff70c8390de40cae279
+  # url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "-rc") }}.src.tar.xz.sig
+  # sha256: 2072bd79df3e0d8289d8de56593f3dac9e722906e931dff70c8390de40cae279
 
 build:
   number: 0
@@ -21,10 +21,11 @@ outputs:
     # we don't cross-compile on windows -> no symlinks
     requirements:
       - flang ={{ version }}
+      - flang-rt_{{ cross_target_platform }} ={{ version }}
+      - compiler-rt_{{ cross_target_platform }} ={{ version }}
       - lld                     # [win]
       # for llvm-ar.exe
       - llvm-tools              # [win]
-      - compiler-rt_{{ cross_target_platform }} ={{ version }}
     test:
       commands:
         - {{ CBUILD }}-flang --version  # [unix]
@@ -34,8 +35,8 @@ outputs:
     script: install_flang.sh  # [unix]
     script: install_flang.bat  # [win]
     run_exports:
-      strong:   # [unix]
-        - libflang >={{ version }}  # [unix]
+      strong:                           # [unix]
+        - libflang-rt >={{ version }}   # [unix]
     requirements:
       build:
         - sed       # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ outputs:
       - flang ={{ version }}
       - flang-rt_{{ cross_target_platform }} ={{ version }}
       - compiler-rt_{{ cross_target_platform }} ={{ version }}
+      - libflang-rt             # [unix]
       - lld                     # [win]
       # for llvm-ar.exe
       - llvm-tools              # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
   name: flang-activation
   version: {{ version }}
 
-source:
+# source:
   # unused, but helpful so the bot creates updates automatically;
   # we use the _signature_, which is tiny and thus much faster to download
   url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "-rc") }}.src.tar.xz.sig


### PR DESCRIPTION
This is the follow-up of https://github.com/conda-forge/flang-feedstock/pull/80 & https://github.com/conda-forge/staged-recipes/pull/29582, in order to adapt to the big runtime refactor that landed in https://github.com/llvm/llvm-project/commit/b55f7512a76f2358000139074c79d4c2521588de (and many other commits).