### PR TITLE
only set FC_LD, not general LD

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -5,7 +5,7 @@ set "CONDA_BACKUP_LDFLAGS=%LDFLAGS%"
 set "CONDA_BACKUP_AR=%AR%"
 
 set "FC=flang.exe"
-set "LD=lld-link.exe"
+set "FC_LD=lld-link.exe"
 set "AR=llvm-ar.exe"
 
 :: following https://github.com/conda-forge/clang-win-activation-feedstock/blob/main/recipe/activate-clang_win-64.bat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: ae3d2c245f1074dec671c8472ebc852603a52aebd7191bd08346411dc5f9b352
 
 build:
-  number: 0
+  number: 1
   # intentionally only windows (main target) & linux (debuggability)
   skip: true  # [osx]
 


### PR DESCRIPTION
Fixes #25

`LD` is the general linker, `FC_LD` should be picked up (at least by meson) as the fortran-specific one. Let's try to restrict this to the more specific one; if the v20 migration runs into issues, we can add back LD.